### PR TITLE
fix double prefix in devDependencies

### DIFF
--- a/bin/autod
+++ b/bin/autod
@@ -39,11 +39,13 @@ if (argv.prefix && argv.prefix !== '>=') {
   argv.prefix = '~';
 }
 
+var re = new RegExp('^' + argv.prefix);
 function outputDep(name, values) {
   var str = util.format('  "%s": {\n', name);
   var deps = [];
   for (var key in values) {
-    deps.push(util.format('    "%s": "%s%s"', key, argv.prefix || '', values[key]));
+    var val = values[key].replace(re, '');
+    deps.push(util.format('    "%s": "%s%s"', key, argv.prefix || '', val));
   }
   str += deps.sort().join(',\n') + '\n  }';
   return str;


### PR DESCRIPTION
package.json

```
{
  "name": "a",
  "devDependencies": {
    "should": "~0.1.0"
  }
}
```

run `autod -f ~` yield

```
[DEPENDENCIES]

  "dependencies": {

  },
  "devDependencies": {
    "should": "~~0.1.0"
  }
```
