### PR TITLE
bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autod",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "auto generate dependencies",
   "keywords": [],
   "author": "dead_horse <dead_horse@qq.com>",
@@ -15,14 +15,14 @@
   "dependencies": {
     "bagpipe": "~0.3.5",
     "colors": "~1.0.3",
-    "commander": "~2.6.0",
-    "crequire": "~1.5.3",
-    "debug": "~2.1.1",
-    "eventproxy": "~0.3.2",
-    "minimatch": "~2.0.1",
+    "commander": "~2.8.1",
+    "crequire": "~1.6.0",
+    "debug": "~2.1.3",
+    "eventproxy": "~0.3.3",
+    "minimatch": "~2.0.4",
     "printable": "~0.0.3",
-    "semver": "~4.3.0",
-    "urllib": "~2.2.2"
+    "semver": "~4.3.3",
+    "urllib": "~2.3.4"
   },
   "devDependencies": {
     "mm": "0.2.0",


### PR DESCRIPTION
Upgrade out-of-date dependencies. The upgrade of semver dependency fixes [a security vulnerability](https://nodesecurity.io/advisories/semver_redos).