### PR TITLE
chore(deps): upgrade babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
   "bin": {
     "autod": "bin/autod.js"
   },
-  "main": "index",
   "dependencies": {
-    "babel-core": "~6.7.6",
+    "babel-core": "~6.11.4",
     "babel-preset-react": "~6.5.0",
     "babel-preset-es2015": "~6.6.0",
     "babel-preset-stage-0": "~6.5.0",
@@ -30,8 +29,5 @@
     "printable": "~0.0.3",
     "semver": "~5.1.0",
     "urllib": "~2.8.0"
-  },
-  "devDependencies": {
-
   }
 }


### PR DESCRIPTION
Reason for minimatch security vulnerability