### PR TITLE
feat: add depignore options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,6 +48,7 @@ $ bin/autod -h
     -D, --devdep <dev dependently modules>               modules that not require in source file, but you need them in as devDependencies
     -k, --keep <dependently modules>                     modules that you want to keep version in package.json file
     -s, --semver <dependencies@version>                  auto update these modules within the specified semver
+    --depignore <modules>                                modules that you want to ignore, it useful in modules alias or lerna project
 ```
 
 * Autod will parse all the js files in `path`, and you can exclude folder by `-e, --exclude`.

--- a/bin/autod.js
+++ b/bin/autod.js
@@ -32,6 +32,7 @@ const argv = program
   .option('-n, --notransform', 'disable transfrom es next, don\'t support es6 modules')
   .option('-P, --plugin <name>', 'plugin module name')
   .option('--check', 'check missing dependencies and devDependencies')
+  .option('--depignore <modules>', 'ignore modules, these modules would be ignore and excluded')
   .parse(process.argv);
 
 let options = {};
@@ -53,7 +54,7 @@ for (const key in argv) {
   }
 }
 
-[ 'exclude', 'dep', 'devdep', 'test', 'keep' ].forEach(function(key) {
+[ 'exclude', 'dep', 'devdep', 'depignore', 'test', 'keep' ].forEach(function(key) {
   options[key] = split(options[key]);
 });
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class Autod extends EventEmitter {
     options.registry = options.registry.replace(/\/?$/, '');
     options.dep = options.dep || [];
     options.devdep = options.devdep || [];
+    options.depignore = options.depignore || [];
     options.root = path.resolve(this.options.root);
     if (options.plugin) {
       try {
@@ -189,6 +190,7 @@ class Autod extends EventEmitter {
       let name = parsed[2];
       if (scope) name = scope + name;
       if (this._isCoreModule(name)) return;
+      if (this.options.depignore.includes(name)) return;
       modules.push(name);
       this.dependencyMap[name] = this.dependencyMap[name] || [];
       this.dependencyMap[name].push(filePath);

--- a/test/autod.test.js
+++ b/test/autod.test.js
@@ -54,6 +54,16 @@ describe('autod', () => {
     assert(!res.stdout.match(/egg/));
   });
 
+  it('should support add depignore modules', function* () {
+    const cwd = path.join(__dirname, 'fixtures/depignore');
+    const res = yield coffee.fork(autod, [ '--prefix=^', '--depignore=umi' ], { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
+    assert(res.stdout.match(/egg/));
+    assert(!res.stdout.match(/umi/));
+  });
+
   it('should support add semver', () => {
     const cwd = path.join(__dirname, 'fixtures/check-pkg');
     return coffee.fork(autod, [ '--prefix=^', '--semver=debug@1' ], { cwd })

--- a/test/check.test.js
+++ b/test/check.test.js
@@ -11,8 +11,8 @@ describe('autod --check', () => {
     return coffee.fork(autod, [ '--check' ], { cwd })
       .debug()
       .expect('code', 1)
-      .expect('stderr', /\[ERROR\] Missing dependencies: \["debug"\]/)
-      .expect('stderr', /\[ERROR\] Missing devDependencies: \["urllib"\]/)
+      .expect('stderr', /Missing dependencies: \["debug"\]/)
+      .expect('stderr', /Missing devDependencies: \["urllib"\]/)
       .end();
   });
 

--- a/test/fixtures/depignore/fixtures/foo.js
+++ b/test/fixtures/depignore/fixtures/foo.js
@@ -1,0 +1,2 @@
+require('egg');
+require('umi');

--- a/test/fixtures/depignore/index.js
+++ b/test/fixtures/depignore/index.js
@@ -1,0 +1,1 @@
+require('debug');

--- a/test/fixtures/depignore/package.json
+++ b/test/fixtures/depignore/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "missing-deps-demo"
+}

--- a/test/fixtures/depignore/package.json
+++ b/test/fixtures/depignore/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "missing-deps-demo"
+  "name": "depignore-demo"
 }

--- a/test/fixtures/depignore/test/fixtures/foo.js
+++ b/test/fixtures/depignore/test/fixtures/foo.js
@@ -1,0 +1,1 @@
+require('egg');

--- a/test/fixtures/depignore/test/foo.test.js
+++ b/test/fixtures/depignore/test/foo.test.js
@@ -1,0 +1,1 @@
+require('urllib');


### PR DESCRIPTION
In the `monorepo` project, many modules are on local and `autod` should ignore this modules. so, add `depignore` options for support it.