### PR TITLE
plugin 插件可以访问  autod 中已解析的出的依赖

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ class Autod extends EventEmitter {
 
     // support plugin parse file
     if (this.options.plugin) {
-      const pluginModules = this.options.plugin(filePath, file) || [];
+      const pluginModules = this.options.plugin(filePath, file, modules) || [];
       pluginModules.forEach(name => {
         modules.push(name);
         this.dependencyMap[name] = this.dependencyMap[name] || [];


### PR DESCRIPTION
plugin 组件并能不修改 autod 中解析的出的依赖，，建议将 modulse 变量传递给 plugin